### PR TITLE
Remove '_CMD' from ioctl commands

### DIFF
--- a/bfbuilder/src/platform/linux/entry.c
+++ b/bfbuilder/src/platform/linux/entry.c
@@ -186,10 +186,10 @@ dev_unlocked_ioctl(
     struct file *file, unsigned int cmd, unsigned long arg)
 {
     switch (cmd) {
-        case IOCTL_CREATE_VM_FROM_BZIMAGE_CMD:
+        case IOCTL_CREATE_VM_FROM_BZIMAGE:
             return ioctl_create_vm_from_bzimage((struct create_vm_from_bzimage_args *)arg);
 
-        case IOCTL_DESTROY_CMD:
+        case IOCTL_DESTROY:
             return ioctl_destroy((domainid_t *)arg);
 
         default:

--- a/bfbuilder/src/platform/windows/queue.c
+++ b/bfbuilder/src/platform/windows/queue.c
@@ -253,12 +253,12 @@ bfbuilderEvtIoDeviceControl(
     }
 
     switch (IoControlCode) {
-        case IOCTL_CREATE_VM_FROM_BZIMAGE_CMD:
+        case IOCTL_CREATE_VM_FROM_BZIMAGE:
             ret = ioctl_create_vm_from_bzimage((struct create_vm_from_bzimage_args *)in);
             RtlCopyMemory(out, in, out_size);
             break;
 
-        case IOCTL_DESTROY_CMD:
+        case IOCTL_DESTROY:
             ret = ioctl_destroy((domainid_t *)in);
             break;
 

--- a/bfexec/src/platform/linux/ioctl_private.cpp
+++ b/bfexec/src/platform/linux/ioctl_private.cpp
@@ -70,15 +70,15 @@ void
 ioctl_private::call_ioctl_create_vm_from_bzimage(
     create_vm_from_bzimage_args &args)
 {
-    if (bfm_write_ioctl(fd, IOCTL_CREATE_VM_FROM_BZIMAGE_CMD, &args) < 0) {
-        throw std::runtime_error("ioctl failed: IOCTL_CREATE_VM_FROM_BZIMAGE_CMD");
+    if (bfm_write_ioctl(fd, IOCTL_CREATE_VM_FROM_BZIMAGE, &args) < 0) {
+        throw std::runtime_error("ioctl failed: IOCTL_CREATE_VM_FROM_BZIMAGE");
     }
 }
 
 void
 ioctl_private::call_ioctl_destroy(domainid_t domainid) noexcept
 {
-    if (bfm_write_ioctl(fd, IOCTL_DESTROY_CMD, &domainid) < 0) {
-        std::cerr << "[ERROR] ioctl failed: IOCTL_DESTROY_CMD\n";
+    if (bfm_write_ioctl(fd, IOCTL_DESTROY, &domainid) < 0) {
+        std::cerr << "[ERROR] ioctl failed: IOCTL_DESTROY\n";
     }
 }

--- a/bfexec/src/platform/windows/ioctl_private.cpp
+++ b/bfexec/src/platform/windows/ioctl_private.cpp
@@ -124,15 +124,15 @@ ioctl_private::~ioctl_private()
 void
 ioctl_private::call_ioctl_create_vm_from_bzimage(create_vm_from_bzimage_args &args)
 {
-    if (bfm_read_write_ioctl(fd, IOCTL_CREATE_VM_FROM_BZIMAGE_CMD, &args, sizeof(create_vm_from_bzimage_args)) < 0) {
-        throw std::runtime_error("ioctl failed: IOCTL_CREATE_VM_FROM_BZIMAGE_CMD");
+    if (bfm_read_write_ioctl(fd, IOCTL_CREATE_VM_FROM_BZIMAGE, &args, sizeof(create_vm_from_bzimage_args)) < 0) {
+        throw std::runtime_error("ioctl failed: IOCTL_CREATE_VM_FROM_BZIMAGE");
     }
 }
 
 void
 ioctl_private::call_ioctl_destroy(domainid_t domainid) noexcept
 {
-    if (bfm_read_write_ioctl(fd, IOCTL_DESTROY_CMD, &domainid, sizeof(domainid_t)) < 0) {
-        std::cerr << "[ERROR] ioctl failed: IOCTL_DESTROY_CMD\n";
+    if (bfm_read_write_ioctl(fd, IOCTL_DESTROY, &domainid, sizeof(domainid_t)) < 0) {
+        std::cerr << "[ERROR] ioctl failed: IOCTL_DESTROY\n";
     }
 }


### PR DESCRIPTION
The builder interface defines IOCTLs for creating and destroying guests.
Before this patch, the defines with a '_CMD' suffix were being used in
ioctl_private and the ioctl handler in the linux/windows drivers.

Use the IOCTL command defines without the '_CMD' suffix in those
locations.

Signed-off-by: Connor Davis <davisc@ainfosec.com>