### PR TITLE
Use target-based cmake as in the base hypervisor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,13 +46,7 @@ endif()
 if(ENABLE_BUILD_VMM)
     vmm_extension(
         boxy_bfvmm
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/src
-    )
-
-    vmm_extension(
-        boxy_bfvmm_main
-        DEPENDS boxy_bfvmm
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/src/main
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm
     )
 endif()
 
@@ -62,8 +56,9 @@ endif()
 
 userspace_extension(
     bfexec
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfexec/src
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfexec
     DEPENDS bfintrinsics
+    DEPENDS bfsdk
     DEPENDS cxxopts
 )
 

--- a/bfexec/CMakeLists.txt
+++ b/bfexec/CMakeLists.txt
@@ -19,45 +19,29 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(bfexec C CXX)
 
-include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project(
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../../bfvmm/include
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../../bfsdk/include
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
+init_project(bfexec BINARY)
+
+string(TOLOWER ${BUILD_TARGET_OS} OS)
+
+target_link_libraries(bfexec PUBLIC
+    userspace::bfroot
+    userspace::bfintrinsics
+    $<$<BOOL:${UNIX}>:pthread>
+    $<$<OR:$<BOOL:${CYGWIN}>,$<BOOL:${WIN32}>>:setupapi>
+)
+target_include_directories(bfexec PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../bfsdk/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../bfvmm/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src/platform/${OS}>
+)
+target_sources(bfexec PRIVATE
+    src/main.cpp
+    src/platform/${OS}/ioctl.cpp
+    src/platform/${OS}/ioctl_private.cpp
 )
 
-if(BUILD_TARGET_OS STREQUAL "Linux")
-    list(APPEND SOURCES
-        platform/linux/ioctl.cpp
-        platform/linux/ioctl_private.cpp
-    )
-    include_directories(platform/linux/)
-elseif(BUILD_TARGET_OS STREQUAL "Windows")
-    list(APPEND SOURCES
-        platform/windows/ioctl.cpp
-        platform/windows/ioctl_private.cpp
-    )
-    include_directories(platform/windows/)
-else()
-    message(FATAL_ERROR "Unsupported OS: ${BUILD_TARGET_OS}")
-endif()
-
-list(APPEND SOURCES
-    main.cpp
-)
-
-add_executable(bfexec ${SOURCES})
-target_link_static_libraries(bfexec bfintrinsics)
-
-if(CYGWIN OR WIN32)
-    target_link_libraries(bfexec setupapi)
-endif()
-
-if(UNIX)
-    target_link_libraries(bfexec pthread)
-endif()
-
-install(TARGETS bfexec DESTINATION bin)
+fini_project()

--- a/bflinux/CMakeLists.txt
+++ b/bflinux/CMakeLists.txt
@@ -19,23 +19,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(bflinux C CXX)
 
-include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(bflinux INTERFACE)
 
-list(APPEND SOURCES
-    init.cpp
-)
+target_link_libraries(bflinux INTERFACE userspace::bfintrinsics)
 
-set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-set(BUILD_SHARED_LIBRARIES OFF)
-set(CMAKE_EXE_LINKER_FLAGS "-static")
-
-add_executable(init ${SOURCES})
-target_link_static_libraries(init bfintrinsics)
-
+add_executable(init init.cpp)
+target_link_options(init PRIVATE -static)
+target_link_libraries(init PRIVATE bflinux)
 add_custom_command(
     TARGET init POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PREFIXES_DIR}/initrd/
@@ -45,4 +38,6 @@ add_custom_command(
     VERBATIM
 )
 
-install(TARGETS init DESTINATION bin)
+install(TARGETS init DESTINATION bin EXPORT bflinux-userspace-targets)
+
+fini_project()

--- a/bfvmm/CMakeLists.txt
+++ b/bfvmm/CMakeLists.txt
@@ -20,20 +20,37 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.13)
-project(boxy C CXX)
+project(boxy_bfvmm C CXX)
 
-include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project(
-    INCLUDES ${PROJECT_SOURCE_DIR}/../include
-    INCLUDES ${PROJECT_SOURCE_DIR}/../../include
-    INCLUDES ${PROJECT_SOURCE_DIR}/../../bfsdk/include
-)
+init_project(boxy_bfvmm INTERFACE)
 
-add_subdirectory(domain)
-add_subdirectory(hve)
+# -----------------------------------------------------------------------------
+# Generator expressions
+# -----------------------------------------------------------------------------
+
+set(X64 $<STREQUAL:${BUILD_TARGET_ARCH},x86_64>)
+set(BUILD $<BOOL:$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>>)
+set(BUILD_INCLUDE $<AND:$<COMPILE_LANGUAGE:CXX>,${BUILD}>)
+
+# -----------------------------------------------------------------------------
+# VMM
+# -----------------------------------------------------------------------------
+
+add_subdirectory(src/domain)
+add_subdirectory(src/hve)
+
+add_executable(boxy_vmm)
+target_sources(boxy_vmm PRIVATE $<${X64}:src/main/arch/intel_x64/vcpu_factory.cpp>)
+target_sources(boxy_vmm PRIVATE $<${X64}:src/main/arch/intel_x64/domain_factory.cpp>)
+
+target_link_libraries(boxy_bfvmm INTERFACE boxy_domain boxy_hve)
+target_link_libraries(boxy_vmm PRIVATE boxy_bfvmm)
 
 # -----------------------------------------------------------------------------
 # Install
 # -----------------------------------------------------------------------------
 
-install(DIRECTORY ../include/ DESTINATION include/boxy)
+install(DIRECTORY include/ DESTINATION include/boxy)
+install(TARGETS boxy_vmm DESTINATION bin EXPORT boxy-vmm-targets)
+
+fini_project()

--- a/bfvmm/include/domain/domain.h
+++ b/bfvmm/include/domain/domain.h
@@ -27,22 +27,6 @@
 #include <bfhypercall.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_DOMAIN
-#ifdef SHARED_BOXY_DOMAIN
-#define EXPORT_BOXY_DOMAIN EXPORT_SYM
-#else
-#define EXPORT_BOXY_DOMAIN IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_DOMAIN
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -51,7 +35,7 @@ namespace boxy
 
 /// Domain
 ///
-class EXPORT_BOXY_DOMAIN domain : public bfobject
+class domain : public bfobject
 {
 public:
 

--- a/bfvmm/include/domain/domain_factory.h
+++ b/bfvmm/include/domain/domain_factory.h
@@ -26,27 +26,6 @@
 #include "domain.h"
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_DOMAIN
-#ifdef SHARED_BOXY_DOMAIN
-#define EXPORT_BOXY_DOMAIN EXPORT_SYM
-#else
-#define EXPORT_BOXY_DOMAIN IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_DOMAIN
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -55,7 +34,7 @@ namespace boxy
 
 /// Domain Factory
 ///
-class EXPORT_BOXY_DOMAIN domain_factory
+class domain_factory
 {
 public:
 
@@ -99,9 +78,5 @@ public:
 };
 
 }
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #endif

--- a/bfvmm/include/hve/arch/intel_x64/apic/x2apic.h
+++ b/bfvmm/include/hve/arch/intel_x64/apic/x2apic.h
@@ -27,22 +27,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/wrmsr.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -51,7 +35,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE x2apic_handler
+class x2apic_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/domain.h
+++ b/bfvmm/include/hve/arch/intel_x64/domain.h
@@ -32,22 +32,6 @@
 #include <bfvmm/hve/arch/intel_x64/vcpu.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -58,7 +42,7 @@ class vcpu;
 
 /// Domain
 ///
-class EXPORT_BOXY_HVE domain : public boxy::domain
+class domain : public boxy::domain
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/pci/pci_configuration_space.h
+++ b/bfvmm/include/hve/arch/intel_x64/pci/pci_configuration_space.h
@@ -26,22 +26,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/io_instruction.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -50,7 +34,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE pci_configuration_space_handler
+class pci_configuration_space_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/uart.h
+++ b/bfvmm/include/hve/arch/intel_x64/uart.h
@@ -33,22 +33,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/cpuid.h>
 #include <bfvmm/hve/arch/intel_x64/vmexit/io_instruction.h>
 
-// -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
 //------------------------------------------------------------------------------
 // Definition
 //------------------------------------------------------------------------------
@@ -58,7 +42,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE uart
+class uart
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vcpu.h
+++ b/bfvmm/include/hve/arch/intel_x64/vcpu.h
@@ -42,22 +42,6 @@
 #include <bfvmm/vcpu/vcpu_manager.h>
 #include <bfvmm/hve/arch/intel_x64/vcpu.h>
 
-// -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
 //------------------------------------------------------------------------------
 // Definition
 //------------------------------------------------------------------------------
@@ -65,7 +49,7 @@
 namespace boxy::intel_x64
 {
 
-class EXPORT_BOXY_HVE vcpu : public bfvmm::intel_x64::vcpu
+class vcpu : public bfvmm::intel_x64::vcpu
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmcall/domain_op.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcall/domain_op.h
@@ -25,22 +25,6 @@
 #include <bfvmm/hve/arch/intel_x64/vcpu.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -49,7 +33,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE vmcall_domain_op_handler
+class vmcall_domain_op_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmcall/run_op.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcall/run_op.h
@@ -26,22 +26,6 @@
 #include <bfvmm/hve/arch/intel_x64/vcpu.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -50,7 +34,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE vmcall_run_op_handler
+class vmcall_run_op_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmcall/vcpu_op.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcall/vcpu_op.h
@@ -25,22 +25,6 @@
 #include <bfvmm/hve/arch/intel_x64/vcpu.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -49,7 +33,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE vmcall_vcpu_op_handler
+class vmcall_vcpu_op_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/cpuid.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/cpuid.h
@@ -26,22 +26,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/cpuid.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -50,7 +34,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE cpuid_handler
+class cpuid_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/external_interrupt.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/external_interrupt.h
@@ -26,22 +26,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/external_interrupt.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -50,7 +34,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE external_interrupt_handler
+class external_interrupt_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/io_instruction.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/io_instruction.h
@@ -26,22 +26,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/io_instruction.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -50,7 +34,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE io_instruction_handler
+class io_instruction_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/msr.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/msr.h
@@ -29,22 +29,6 @@
 #include <unordered_map>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -53,7 +37,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE msr_handler
+class msr_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/mtrr.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/mtrr.h
@@ -27,22 +27,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/wrmsr.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -51,7 +35,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE mtrr_handler
+class mtrr_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/vmcall.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/vmcall.h
@@ -25,22 +25,6 @@
 #include <bfvmm/hve/arch/intel_x64/vcpu.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -49,7 +33,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE vmcall_handler
+class vmcall_handler
 {
 public:
 

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/yield.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/yield.h
@@ -27,22 +27,6 @@
 #include <bfvmm/hve/arch/intel_x64/vmexit/wrmsr.h>
 
 // -----------------------------------------------------------------------------
-// Exports
-// -----------------------------------------------------------------------------
-
-#include <bfexports.h>
-
-#ifndef STATIC_BOXY_HVE
-#ifdef SHARED_BOXY_HVE
-#define EXPORT_BOXY_HVE EXPORT_SYM
-#else
-#define EXPORT_BOXY_HVE IMPORT_SYM
-#endif
-#else
-#define EXPORT_BOXY_HVE
-#endif
-
-// -----------------------------------------------------------------------------
 // Definitions
 // -----------------------------------------------------------------------------
 
@@ -51,7 +35,7 @@ namespace boxy::intel_x64
 
 class vcpu;
 
-class EXPORT_BOXY_HVE yield_handler
+class yield_handler
 {
 public:
 

--- a/bfvmm/src/domain/CMakeLists.txt
+++ b/bfvmm/src/domain/CMakeLists.txt
@@ -19,22 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-list(APPEND SOURCES
-    domain.cpp
+add_library(boxy_domain domain.cpp)
+
+target_link_libraries(boxy_domain PUBLIC vmm::bfvmm)
+target_include_directories(boxy_domain PUBLIC
+    $<${BUILD_INCLUDE}:${PROJECT_SOURCE_DIR}/include>
+    $<${BUILD_INCLUDE}:${PROJECT_SOURCE_DIR}/../bfsdk/include>
 )
 
-add_shared_library(
-    boxy_domain
-    SOURCES ${SOURCES}
-    DEFINES SHARED_BOXY_DOMAIN
-    DEFINES SHARED_MEMORY_MANAGER
-    DEFINES SHARED_INTRINSICS
-)
-
-add_static_library(
-    boxy_domain
-    SOURCES ${SOURCES}
-    DEFINES STATIC_BOXY_DOMAIN
-    DEFINES STATIC_MEMORY_MANAGER
-    DEFINES STATIC_INTRINSICS
-)
+install(TARGETS boxy_domain DESTINATION lib EXPORT boxy_bfvmm-vmm-targets)

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -19,47 +19,29 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
-    list(APPEND SOURCES
-        arch/intel_x64/apic/x2apic.cpp
-        arch/intel_x64/pci/pci_configuration_space.cpp
-        arch/intel_x64/vmexit/cpuid.cpp
-        arch/intel_x64/vmexit/external_interrupt.cpp
-        arch/intel_x64/vmexit/io_instruction.cpp
-        arch/intel_x64/vmexit/msr.cpp
-        arch/intel_x64/vmexit/mtrr.cpp
-        arch/intel_x64/vmexit/vmcall.cpp
-        arch/intel_x64/vmexit/yield.cpp
-        arch/intel_x64/vmcall/domain_op.cpp
-        arch/intel_x64/vmcall/run_op.cpp
-        arch/intel_x64/vmcall/vcpu_op.cpp
-        arch/intel_x64/domain.cpp
-        arch/intel_x64/uart.cpp
-        arch/intel_x64/vcpu.cpp
-    )
+add_library(boxy_hve)
 
-elseif(${BUILD_TARGET_ARCH} STREQUAL "aarch64")
-    message(WARNING "Unimplemented")
-else()
-    message(FATAL_ERROR "Unsupported architecture")
-endif()
-
-add_shared_library(
-    boxy_hve
-    SOURCES ${SOURCES}
-    DEFINES SHARED_BOXY_HVE
-    DEFINES SHARED_EAPIS_HVE
-    DEFINES SHARED_HVE
-    DEFINES SHARED_MEMORY_MANAGER
-    DEFINES SHARED_INTRINSICS
+target_link_libraries(boxy_hve PUBLIC vmm::bfvmm boxy_domain)
+target_include_directories(boxy_hve PUBLIC
+    $<${BUILD_INCLUDE}:${PROJECT_SOURCE_DIR}/include>
+    $<${BUILD_INCLUDE}:${PROJECT_SOURCE_DIR}/../bfsdk/include>
+)
+target_sources(boxy_hve PRIVATE
+    $<${X64}:arch/intel_x64/apic/x2apic.cpp>
+    $<${X64}:arch/intel_x64/pci/pci_configuration_space.cpp>
+    $<${X64}:arch/intel_x64/vmexit/cpuid.cpp>
+    $<${X64}:arch/intel_x64/vmexit/external_interrupt.cpp>
+    $<${X64}:arch/intel_x64/vmexit/io_instruction.cpp>
+    $<${X64}:arch/intel_x64/vmexit/msr.cpp>
+    $<${X64}:arch/intel_x64/vmexit/mtrr.cpp>
+    $<${X64}:arch/intel_x64/vmexit/vmcall.cpp>
+    $<${X64}:arch/intel_x64/vmexit/yield.cpp>
+    $<${X64}:arch/intel_x64/vmcall/domain_op.cpp>
+    $<${X64}:arch/intel_x64/vmcall/run_op.cpp>
+    $<${X64}:arch/intel_x64/vmcall/vcpu_op.cpp>
+    $<${X64}:arch/intel_x64/domain.cpp>
+    $<${X64}:arch/intel_x64/uart.cpp>
+    $<${X64}:arch/intel_x64/vcpu.cpp>
 )
 
-add_static_library(
-    boxy_hve
-    SOURCES ${SOURCES}
-    DEFINES STATIC_BOXY_HVE
-    DEFINES STATIC_EAPIS_HVE
-    DEFINES STATIC_HVE
-    DEFINES STATIC_MEMORY_MANAGER
-    DEFINES STATIC_INTRINSICS
-)
+install(TARGETS boxy_hve DESTINATION lib EXPORT boxy_bfvmm-vmm-targets)

--- a/bfvmm/src/main/CMakeLists.txt
+++ b/bfvmm/src/main/CMakeLists.txt
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.13)
 project(boxy_bfvmm_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)


### PR DESCRIPTION
- Remove EXPORT/IMPORT boilerplate for shared libraries
  since only static libraries are supported now.
- Port bfvmm, bflinux, and bfexec cmake scripts to use
  the new target design from the base hypervisor

Signed-off-by: Connor Davis <davisc@ainfosec.com>